### PR TITLE
Initial base manifest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ It is made up of 3 parts:
 3. A React based frontend for easily seeing the state and filling missing/outdated
    secrets
 
+## Deploying
+
+I have included some base k8s manifests defined via kustomize, if you just want to
+deploy locally (with kustomize) you can add a `kustomization.yaml` file like:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/jdost/rahsia//manifests/?timeout=120
+```
+
+and then you can just deploy/apply via `kubectl apply -k .` and it will generate the
+resources via kustomize and deploy.  (See kustomize docs for various transforms,
+can include additional resources like an ingress if you want one)
+
 ## Developing
 
 Since the k8s side is written to expect being in cluster, you should go into the

--- a/manifests/clusterrole.yaml
+++ b/manifests/clusterrole.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rahsia
+
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - create
+  - patch
+  - update
+  - watch
+- apiGroups: ["jdost.us"]
+  resources:
+  - secretrequests
+  verbs:
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rahsia
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rahsia
+subjects:
+- kind: ServiceAccount
+  name: rahsia
+  namespace: default

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rahsia
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rahsia
+  template:
+    metadata:
+      labels:
+        app: rahsia
+        app.kubernetes.io/name: rahsia
+    spec:
+      serviceAccountName: rahsia
+      automountServiceAccountToken: true
+      containers:
+      - name: rahsia
+        image: ghcr.io/jdost/rahsia:latest
+        command:
+        - "uvicorn"
+        - "--host"
+        - "0.0.0.0"
+        - "rahsia:app"
+        ports:
+        - containerPort: 8000
+          name: http
+        resources:
+          requests:
+            cpu: "0.1"
+            memory: "128Mi"
+          limits:
+            cpu: "0.25"
+            memory: "256Mi"

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -3,3 +3,7 @@ kind: Kustomization
 
 resources:
 - ./crd/SecretRequest.yaml
+- ./serviceaccount.yaml
+- ./clusterrole.yaml
+- ./deployment.yaml
+- ./service.yaml

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rahsia
+
+spec:
+  selector:
+    app: rahsia
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: http
+    name: http

--- a/manifests/serviceaccount.yaml
+++ b/manifests/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rahsia
+
+secrets:
+  - name: rahsia


### PR DESCRIPTION
This points at the new ghcr artifact, using the `default` namespace to simplify the clusterolebinding transform for users that want to shift to other namespaces.

Verified using as base, input:
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

namespace: management # testing the namespace lands in the ClusterRoleBinding

resources:
- https://github.com/jdost/rahsia//manifests/?timeout=120&ref=flesh-out-deployment
```